### PR TITLE
Update module name to TextformatterInsertDummyContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TextFormatterInsertDummyContent
+# TextformatterInsertDummyContent
 
-A TextFormatter for ProcessWire CMS/CMF that aims to aid development by allowing the quick insertion of dummy text via shortcodes.
+A Textformatter for ProcessWire CMS/CMF that aims to aid development by allowing the quick insertion of dummy text via shortcodes.
 
 Usage is simple - just type for example **[dc3]** into a textarea with this textformatter applied (plain textarea or CKEditor) and it will be replaced at runtime by **3** paragraphs of dummy content. It can also be used to populate text fields (for headings etc) using e.g. **[dc4w]**. This will produce **4 w**ords (rather than paragraphs) at runtime.
 
@@ -12,3 +12,15 @@ Usage is simple - just type for example **[dc3]** into a textarea with this text
 - [dc3-6w] - Show 3 to 6 words randomly per page load ([dc:3-6w] does the same).
 
 The actual content comes from an included 'dummytext.txt' file containing 50 paragraphs of 'Lorem ipsum' from [lipsum.com](http://www.lipsum.com/). The 50 paragraphs is arbitrary - it could be 10 or 100 or anything in between, and the contents of that file can be changed for your own filler text if you wish.
+
+## Upgrading From versions prior to 1.0.0
+
+Prior to version 1.0.0 this module incorrectly capitalised the file and class name. In order to change this, you need to
+follow this procedure...
+
+- Remove TextFormatterInsertDummyContent from any fields that are using it
+- Uninstall the original module
+- Download the new version
+- Refresh the modules list from the Processwire admin
+- Select and install the TextformatterInsertDummyContent module
+- Re-apply it as a formatter on each field you removed the original from.

--- a/TextformatterInsertDummyContent.module
+++ b/TextformatterInsertDummyContent.module
@@ -18,7 +18,7 @@ class TextformatterInsertDummyContent extends Textformatter {
 		return array(
 			'title' => 'Insert Dummy Content',
 			'summary' => "Development Tool - allows special tags to be replaced by paragraphs or optionally words of dummy content.",
-			'version' => '0.0.3',
+			'version' => '1.0.0',
 		);
 	}
 

--- a/TextformatterInsertDummyContent.module
+++ b/TextformatterInsertDummyContent.module
@@ -24,10 +24,10 @@ class TextformatterInsertDummyContent extends Textformatter {
 
 	public function format(&$str) {
 
-		$textfile = $this->config->paths->siteModules.'TextFormatterInsertDummyContent'.DIRECTORY_SEPARATOR.'dummytext.txt';
+		$textfile = $this->config->paths->siteModules.'TextformatterInsertDummyContent'.DIRECTORY_SEPARATOR.'dummytext.txt';
 
 		if(!file_exists($textfile)){
-			$str = "<span style='color:red'>Error - 'dummytext.txt' not found</span> (TextFormatterInsertDummyContent)";
+			$str = "<span style='color:red'>Error - 'dummytext.txt' not found</span> (TextformatterInsertDummyContent)";
 			return;
 		}
 

--- a/TextformatterInsertDummyContent.module
+++ b/TextformatterInsertDummyContent.module
@@ -18,7 +18,7 @@ class TextformatterInsertDummyContent extends Textformatter {
 		return array(
 			'title' => 'Insert Dummy Content',
 			'summary' => "Development Tool - allows special tags to be replaced by paragraphs or optionally words of dummy content.",
-			'version' => 002,
+			'version' => '0.0.3',
 		);
 	}
 

--- a/TextformatterInsertDummyContent.module
+++ b/TextformatterInsertDummyContent.module
@@ -12,7 +12,7 @@
  *
  */
 
-class TextFormatterInsertDummyContent extends Textformatter {
+class TextformatterInsertDummyContent extends Textformatter {
 
 	public static function getModuleInfo() {
 		return array(

--- a/TextformatterInsertDummyContent.module
+++ b/TextformatterInsertDummyContent.module
@@ -24,6 +24,12 @@ class TextformatterInsertDummyContent extends Textformatter {
 
 	public function format(&$str) {
 
+		static $seeded = false;
+		if (!$seeded) {
+			mt_srand($this->page->id);
+			$seeded = true;
+		}
+
 		$textfile = $this->config->paths->siteModules.'TextformatterInsertDummyContent'.DIRECTORY_SEPARATOR.'dummytext.txt';
 
 		if(!file_exists($textfile)){
@@ -64,8 +70,7 @@ class TextformatterInsertDummyContent extends Textformatter {
 
 		} else {
 
-			$paraStart = $this->page->id % (count($paras) - $showMin);
-
+			$paraStart = mt_rand(0, count($paras) - $showHowMany);
 			for($p = $paraStart; $p < ($paraStart + $showHowMany); $p++){
 			  $out .= "<p>{$paras[$p]}</p>";
 			}
@@ -73,6 +78,5 @@ class TextformatterInsertDummyContent extends Textformatter {
 		}
 
 		$str = str_replace($fullMatch, $out, $str);
-
 	}
 }


### PR DESCRIPTION
This is a breaking-change pull-request that renames the class and module file to match other Textformatters. The procedure for replacing earlier versions is outlined in the readme file.

It also seeds the mt random number generator with the page id on the first call, and then selects paragraphs at random from the dummy content file. The mechanism for selection of words is unchanged from earlier versions.

Thanks for considering this, Dave.